### PR TITLE
chore: adicionar direnv, não rodar zsh no shell hook

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.nix
+++ b/flake.nix
@@ -6,17 +6,14 @@
     utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, utils }: utils.lib.eachDefaultSystem (system:
+  outputs = {nixpkgs, utils, ... }: utils.lib.eachDefaultSystem (system:
     let
-      inherit (builtins) attrValues;
       pkgs = import nixpkgs { inherit system; };
-    in
-    rec {
+    in {
       devShells = rec {
         modpack = pkgs.mkShell {
           name = "modpack";
           nativeBuildInputs = with pkgs; [ packwiz unzip zip yq zsh ];
-          shellHook = "zsh";
         };
         default = modpack;
       };


### PR DESCRIPTION
A shell no momento está quebrada pra quem não usa ssh.

O certo é usar direnv (`direnv allow`) ou deixar o usuário especificar a shell (`nix develop -c $SHELL`)