### PR TITLE
feat: tornar journeymap opcional

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -369,7 +369,7 @@ metafile = true
 
 [[files]]
 file = "mods/journeymap.pw.toml"
-hash = "664a573384edf644e9b788c7c29fe32593917ac8283bb794cc46b471a0a6504a"
+hash = "40a1e86149841006d5754b9d36860c2308183b9720b54c79e35322e70abd0847"
 metafile = true
 
 [[files]]

--- a/mods/journeymap.pw.toml
+++ b/mods/journeymap.pw.toml
@@ -11,3 +11,8 @@ mode = "metadata:curseforge"
 [update.curseforge]
 file-id = 5789363
 project-id = 32274
+
+[option]
+optional = true
+default = true
+description = "Disable if you prefer FTB Chunks's map"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "6c0c21375c4c329ce459cadb0a07db69b9e51f3b5cfc93dfd9dc87ae050bb440"
+hash = "81781eda80bde22a49c30fb479873d9647724bea6e31358467c3131bd0de1676"
 
 [versions]
 forge = "47.3.1"


### PR DESCRIPTION
Mods opcionais funcionam assim:
- Se tem algum mod opcional que vc ainda não decidiu se quer ou não, ele te pergunta
- Se não, suas escolhas são preservadas, mas vc pode clicar um botãozinho pra editar elas.

Coloquei pro journeymap vir selecionado por default, então isso é mais pra quem quer tirar ele não ficar reinstalando sozinho. 