### PR TITLE
fix: fazer night vision do merling funcionar com shader

### DIFF
--- a/config/openloader/data/merling-nightvision-fix/data/origins/powers/water_vision.json
+++ b/config/openloader/data/merling-nightvision-fix/data/origins/powers/water_vision.json
@@ -1,0 +1,39 @@
+{
+  "loading_priority": 1,
+  "type": "origins:multiple",
+
+  "main": {
+    "type": "origins:toggle_night_vision",
+    "strength": 1.0,
+    "condition": {
+      "type": "origins:submerged_in",
+      "fluid": "minecraft:water"
+    },
+    "active_by_default": true,
+    "key": {
+      "key": "key.origins.primary_active",
+      "continuous": false
+    }
+  },
+
+  "helper": {
+    "type": "origins:stacking_status_effect",
+    "min_stacks": 0,
+    "max_stacks": 1,
+    "duration_per_stack": 20,
+    "effects": [
+      {
+        "effect": "minecraft:night_vision",
+        "is_ambient": true,
+        "show_particles": false,
+        "show_icon": false
+      }
+    ],
+    "conditions": [
+      {
+        "type": "origins:power_active",
+        "power": "origins:water_vision_main"
+      }
+    ]
+  }
+}

--- a/config/openloader/data/merling-nightvision-fix/pack.mcmeta
+++ b/config/openloader/data/merling-nightvision-fix/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+    "pack": {
+        "pack_format": 15,
+        "description": "Fixes water_vision not working with shaders"
+    }
+}

--- a/index.toml
+++ b/index.toml
@@ -9,6 +9,14 @@ file = "README.md"
 hash = "f87e90dc6f8b12e860590009e4fdc0fb6cf5173f097bd1b41a475fd6d8e8fb6b"
 
 [[files]]
+file = "config/openloader/data/merling-nightvision-fix/data/origins/powers/water_vision.json"
+hash = "f7eefc1cf5881cb989a81b345e38b02f56394978ab88df55898e0a67223815cc"
+
+[[files]]
+file = "config/openloader/data/merling-nightvision-fix/pack.mcmeta"
+hash = "8fdb62a60df3e9b6f1f7b2fdb0fc1d0faaf55331eeceffd957654f6190b5c640"
+
+[[files]]
 file = "config/openloader/data/merling-notail/data/merling_notail/origins/merling_notail.json"
 hash = "3461831bb793ee5bba026cee0bd729c677c46afff2b3f07d954a881feafa8b42"
 

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "e6556bb84432e1a6a1969edbd44de0d543e13d884d0923e53cecda9ee60d6c1a"
+hash = "cda1356044f1b9a32fa82ce2a1e11e1298c84d2a63b9668a6a38131fc52721cb"
 
 [versions]
 forge = "47.3.1"


### PR DESCRIPTION
O water_vision (e.g. do merling) não funciona com shaders. Criei um override pra ele que, além da night vision "builtin" do origins, tb aplica night vision de poção (só que oculta) qd vc ta na agua e o poder ta toggleado. Assim funciona com shaders.